### PR TITLE
Improve MoviePy compatibility and create README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# Stack Crane Challenge
+
+Stack Crane Challenge est un petit projet de génération de vidéos mettant en scène une grue empilant des blocs.
+Il a été conçu comme exemple d'utilisation de plusieurs bibliothèques Python liées au traitement multimédia et
+à la simulation physique.
+
+## Fonctionnement
+
+Le script génère une vidéo en plusieurs étapes :
+
+1. **Simulation** : la physique est gérée par [Pymunk](https://www.pymunk.org/). Les blocs sont ajoutés au fur et à mesure
+   jusqu'à atteindre un nombre aléatoire d'étages.
+2. **Rendu** : [Pygame](https://www.pygame.org/) est utilisé en mode "headless" pour dessiner chaque frame. Les images et
+   arrière-plans proviennent du dossier `assets/`.
+3. **Audio** : les effets sonores sont assemblés avec [Pydub](https://github.com/jiaaro/pydub) en fonction des événements de la
+   simulation (impacts des blocs, musique d'ambiance, etc.).
+4. **Export** : [MoviePy](https://zulko.github.io/moviepy/) rassemble les frames et la bande son pour produire un fichier MP4.
+
+L'ensemble est orchestré dans `src/batch/batch_generate.py` qui permet de générer une ou plusieurs vidéos à la suite.
+
+## Installation
+
+1. Assurez‑vous de disposer de Python 3.9 ou plus récent.
+2. Clonez ce dépôt puis installez les dépendances :
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Certaines bibliothèques (notamment MoviePy et Pydub) requièrent la présence d'outils externes tels que `ffmpeg`. Veillez à ce
+qu'ils soient accessibles dans votre `PATH` pour un fonctionnement optimal.
+
+## Utilisation
+
+Pour générer une vidéo :
+
+```bash
+python -m src
+```
+
+Par défaut un seul clip d’environ une minute est créé dans le dossier `output/`. Il est possible de spécifier combien de
+vidéos produire en appelant directement le script :
+
+```bash
+python src/batch/batch_generate.py --count 5
+```
+
+Les paramètres généraux (dimensions, durée, vitesses, palettes…) sont définis dans `src/config.py` et peuvent être ajustés
+selon vos besoins.
+
+## Tests
+
+Une suite de tests basée sur `pytest` est fournie. Pour l'exécuter :
+
+```bash
+pytest
+```
+
+## Arborescence
+
+- `src/` : code principal du projet
+  - `physics_sim/` : création de l'espace Pymunk et des blocs
+  - `renderer/` : rendu avec Pygame et gestion des overlays
+  - `audio/` : chargement et mixage des sons
+  - `video_export/` : export final via MoviePy
+- `assets/` : images et sons utilisés pour la génération
+- `tests/` : tests unitaires
+
+Bon empilage !


### PR DESCRIPTION
## Summary
- add a detailed French README with installation and usage instructions
- support newer MoviePy versions in the exporter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fa8a736083249b1b41fa81f1f6ed