### PR TITLE
Add no audio option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ vidéos produire en appelant directement le script :
 python src/batch/batch_generate.py --count 5
 ```
 
+Vous pouvez désactiver la bande son avec l'option `--no-audio` :
+
+```bash
+python src/batch/batch_generate.py --no-audio
+```
+
 Les paramètres généraux (dimensions, durée, vitesses, palettes…) sont définis dans `src/config.py` et peuvent être ajustés
 selon vos besoins.
 


### PR DESCRIPTION
## Summary
- let batch_generate disable audio when `--no-audio` flag is used
- document the option in the README

## Testing
- `pip install -q pygame pymunk moviepy pydub numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fbdc700c83249f754c17eaa1ac5f