### PR TITLE
Fix block physics and moving crane

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -26,12 +26,22 @@ def generate_once(index: int, assets, sounds=None) -> None:
     block_count = random.randint(*config.BLOCK_COUNT_RANGE)
     sky = random.choice(config.SKY_OPTIONS)
     crane_x = config.WIDTH // 2
+    crane_speed = random.randint(*config.GRUE_SPEED_RANGE)
+    crane_dir = 1
     for i in range(config.DURATION * config.FPS):
         t = i / config.FPS
         dynamic_bodies = [b for b in space.bodies if isinstance(b, pymunk.Body) and b.body_type == pymunk.Body.DYNAMIC]
-        if len(dynamic_bodies) < block_count and i % (config.FPS * 2) == 0:
-            block.create_block(space, crane_x, 150, random.choice(list(assets["blocks"].keys())))
+        if len(dynamic_bodies) < block_count and i % (config.FPS * config.BLOCK_DROP_INTERVAL) == 0:
+            drop_x = crane_x + random.randint(*config.DROP_VARIATION_RANGE)
+            block.create_block(space, drop_x, config.HEIGHT - config.CRANE_DROP_HEIGHT, random.choice(list(assets["blocks"].keys())))
             events.append((t, "impact"))
+        crane_x += crane_dir * crane_speed / config.FPS
+        if crane_x > config.WIDTH - config.CRANE_MOVEMENT_BOUNDS:
+            crane_x = config.WIDTH - config.CRANE_MOVEMENT_BOUNDS
+            crane_dir = -1
+        elif crane_x < config.CRANE_MOVEMENT_BOUNDS:
+            crane_x = config.CRANE_MOVEMENT_BOUNDS
+            crane_dir = 1
         space.step(1 / config.FPS)
         arr = pygame_renderer.render_frame(screen, space, assets, crane_x, sky)
         if i < config.FPS * 2:

--- a/src/config.py
+++ b/src/config.py
@@ -7,8 +7,29 @@ HEIGHT = 1920
 FPS = 30
 DURATION = 60  # seconds
 
-BLOCK_COUNT_RANGE = (10, 20)  # number of floors per video
-GRUE_SPEED_RANGE = (150, 300)  # pixels per second
+# Number of blocks that may be dropped in a single video
+BLOCK_COUNT_RANGE = (10, 20)
+
+# Speed of the moving crane in pixels per second
+GRUE_SPEED_RANGE = (50, 120)
+
+# Height from the bottom of the screen where blocks are spawned
+CRANE_DROP_HEIGHT = 150
+
+# Horizontal margin used for crane movement limits
+CRANE_MOVEMENT_BOUNDS = 200
+
+# Random variation applied to the drop X position
+DROP_VARIATION_RANGE = (-30, 30)
+
+# Offset for the hook relative to the top of the crane bar
+HOOK_Y_OFFSET = 80
+
+# Vertical position of the crane bar itself
+CRANE_BAR_Y = 0
+
+# Delay between consecutive block drops in seconds
+BLOCK_DROP_INTERVAL = 2
 
 # Available color palettes for overlays or effects
 PALETTES = {

--- a/src/physics_sim/space_builder.py
+++ b/src/physics_sim/space_builder.py
@@ -7,9 +7,18 @@ from .. import config
 def init_space() -> pymunk.Space:
     """Initialise the physics space with gravity and a static floor."""
     space = pymunk.Space()
-    space.gravity = (0, 900)
+    # In Pymunk the Y axis points upward, so a negative value means gravity
+    # towards the bottom of the screen.  The original code used a positive value
+    # which made the blocks "fall" upwards.  We flip the sign so that the
+    # simulation matches the visual representation used by Pygame.
+    space.gravity = (0, -900)
 
-    floor = pymunk.Segment(space.static_body, (0, config.HEIGHT - 10), (config.WIDTH, config.HEIGHT - 10), 5)
+    # The floor should be located near the bottom of the space.  Previously it
+    # was placed at ``HEIGHT - 10`` which corresponds to the top edge when using
+    # Pymunk's coordinate system.  Moving it near ``y=10`` allows the blocks to
+    # properly land and stack on screen.
+    floor_y = 10
+    floor = pymunk.Segment(space.static_body, (0, floor_y), (config.WIDTH, floor_y), 5)
     floor.friction = 1.0
     space.add(floor)
     return space

--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -38,9 +38,14 @@ def load_assets() -> Dict[str, pygame.Surface]:
 def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_name: str) -> np.ndarray:
     """Render a single frame and return it as a numpy array."""
     surface.blit(assets["sky"][sky_name], (0, 0))
-    surface.blit(assets["crane_bar"], (0, 0))
+    bar_img = assets["crane_bar"]
+    if bar_img.get_width() != config.WIDTH:
+        bar_img = pygame.transform.scale(bar_img, (config.WIDTH, bar_img.get_height()))
+    surface.blit(bar_img, (0, config.CRANE_BAR_Y))
+
     hook_img = assets["hook"]
-    surface.blit(hook_img, (crane_x - hook_img.get_width() // 2, 80))
+    hook_y = config.CRANE_BAR_Y + config.HOOK_Y_OFFSET
+    surface.blit(hook_img, (crane_x - hook_img.get_width() // 2, hook_y))
     for body in space.bodies:
         if isinstance(body, pymunk.Body) and body.body_type != pymunk.Body.DYNAMIC:
             continue
@@ -48,7 +53,10 @@ def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_nam
         if variant and variant in assets["blocks"]:
             img = assets["blocks"][variant]
             x, y = body.position
-            rect = img.get_rect(center=(int(x), int(y)))
+            # Convert from Pymunk's bottom-left origin to Pygame's top-left
+            # coordinate system.
+            py_y = config.HEIGHT - int(y)
+            rect = img.get_rect(center=(int(x), py_y))
             surface.blit(img, rect)
     arr = pygame.surfarray.array3d(surface)
     return np.transpose(arr, (1, 0, 2))

--- a/tests/test_space_builder.py
+++ b/tests/test_space_builder.py
@@ -8,4 +8,4 @@ from src.physics_sim import space_builder
 
 def test_space_has_gravity():
     space = space_builder.init_space()
-    assert space.gravity == (0, 900)
+    assert space.gravity == (0, -900)


### PR DESCRIPTION
## Summary
- adjust Pymunk coordinate system and floor placement
- convert block coordinates when rendering
- move crane horizontally and drop blocks from the top
- update tests for new gravity setting
- add configurable crane parameters and place the crane bar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863013b6a188324b5b44c6480e7f09f