### PR TITLE
Add debug script for stacking test

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ python src/batch/batch_generate.py --no-audio
 Les paramètres généraux (dimensions, durée, vitesses, palettes…) sont définis dans `src/config.py` et peuvent être ajustés
 selon vos besoins.
 
+### Test d'empilage simple
+
+Un script dédié permet de générer rapidement une courte vidéo de diagnostic avec
+deux blocs qui tombent au même endroit. Cela aide à vérifier visuellement que
+l'empilage fonctionne correctement :
+
+```bash
+python -m src.debug.simple_stack_test
+```
+
+Le fichier `output/stack_test.mp4` résultant devrait montrer les deux blocs se
+poser l'un sur l'autre.
+
 ## Tests
 
 Une suite de tests basée sur `pytest` est fournie. Pour l'exécuter :

--- a/src/debug/__init__.py
+++ b/src/debug/__init__.py
@@ -1,0 +1,1 @@
+# Debug utilities for manual tests

--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -1,0 +1,40 @@
+"""Simple diagnostic video generator for block stacking."""
+
+import os
+
+import pygame
+from pydub import AudioSegment
+
+from .. import config
+from ..physics_sim import block, space_builder
+from ..renderer import pygame_renderer
+from ..video_export import moviepy_exporter
+
+
+def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds: int = 10) -> None:
+    """Generate a short video dropping two blocks at the same position."""
+    os.makedirs(config.OUTPUT_DIR, exist_ok=True)
+    assets = pygame_renderer.load_assets()
+    space = space_builder.init_space()
+    screen = pygame.Surface((config.WIDTH, config.HEIGHT))
+
+    crane_x = config.WIDTH // 2
+    drop_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
+    block_variant = next(iter(assets["blocks"]))
+    drop_frames = [config.FPS, config.FPS * 3]
+    total_frames = seconds * config.FPS
+
+    frames = []
+    for i in range(total_frames):
+        if i in drop_frames:
+            block.create_block(space, crane_x, drop_y, block_variant)
+        space.step(1 / config.FPS)
+        arr = pygame_renderer.render_frame(screen, space, assets, crane_x, "skyline_day.png")
+        frames.append(arr)
+
+    audio = AudioSegment.silent(duration=seconds * 1000)
+    moviepy_exporter.export_video(frames, audio, output)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- create `simple_stack_test.py` to drop two blocks at a fixed position
- expose the debug script in the documentation

## Testing
- `pytest -q`
- `python -m src.debug.simple_stack_test`

------
https://chatgpt.com/codex/tasks/task_e_68630883597083249c4a1028dfd86faf