### PR TITLE
Fix block collision and add debug logs

### DIFF
--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -28,6 +28,9 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
     for i in range(total_frames):
         if i in drop_frames:
             block.create_block(space, crane_x, drop_y, block_variant)
+            print(f"Bloc créé à ({crane_x}, {drop_y})")
+            print(f"Nombre de bodies: {len(space.bodies)}")
+            print(f"Nombre de shapes: {len(space.shapes)}")
         space.step(1 / config.FPS)
         arr = pygame_renderer.render_frame(screen, space, assets, crane_x, "skyline_day.png")
         frames.append(arr)

--- a/src/physics_sim/block.py
+++ b/src/physics_sim/block.py
@@ -16,7 +16,12 @@ def create_block(space: pymunk.Space, x: float, y: float, variant: str,
     shape = pymunk.Poly.create_box(body, (width, height))
     shape.friction = 0.7
     shape.elasticity = 0.1
-    # store variant to render corresponding image
+    # ensure the block participates in collisions
+    shape.collision_type = 1
+    shape.group = 0
+
+    # store variant to render the corresponding image
     body.variant = variant
+
     space.add(body, shape)
     return body


### PR DESCRIPTION
## Summary
- ensure blocks collide by setting `collision_type` and `group`
- log debug info whenever a block is spawned in the simple test

## Testing
- `python -m src.debug.simple_stack_test`

------
https://chatgpt.com/codex/tasks/task_e_68630dbdc3648324a71debbc0c0e0062