### PR TITLE
Add debug hitbox rendering and collision test

### DIFF
--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -21,6 +21,23 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
     crane_x = config.WIDTH // 2
     drop_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
     block_variant = next(iter(assets["blocks"]))
+
+    # NEW: create two blocks manually for collision diagnostics
+    block1 = block.create_block(space, 540, 100, block_variant)
+    block2 = block.create_block(space, 540, 200, block_variant)
+
+    print(f"Block1 position: {block1.position}")
+    print(f"Block2 position: {block2.position}")
+
+    block_height = 100  # assuming default size
+    for step in range(10):
+        space.step(1 / config.FPS)
+        print(f"Step {step}: Block1={block1.position}, Block2={block2.position}")
+        b1_top = block1.position.y + block_height / 2
+        b2_bottom = block2.position.y - block_height / 2
+        touching = b2_bottom <= b1_top
+        print(f"  Touching: {touching}")
+
     drop_frames = [config.FPS, config.FPS * 3]
     total_frames = seconds * config.FPS
 

--- a/src/physics_sim/block.py
+++ b/src/physics_sim/block.py
@@ -14,6 +14,11 @@ def create_block(space: pymunk.Space, x: float, y: float, variant: str,
     body = pymunk.Body(mass, moment)
     body.position = x, y
     shape = pymunk.Poly.create_box(body, (width, height))
+
+    # NEW: debug logs for hitbox
+    print(f"Bloc créé - Taille: {width}x{height}")
+    print(f"Vertices de la hitbox: {shape.get_vertices()}")
+    print(f"Aire de la shape: {shape.area}")
     shape.friction = 0.7
     shape.elasticity = 0.1
     # ensure the block participates in collisions

--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -49,6 +49,18 @@ def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_nam
     for body in space.bodies:
         if isinstance(body, pymunk.Body) and body.body_type != pymunk.Body.DYNAMIC:
             continue
+
+        # NEW: draw physical hitboxes in red for debug purposes
+        for shape in body.shapes:
+            if isinstance(shape, pymunk.Poly):
+                vertices = []
+                for v in shape.get_vertices():
+                    x, y = v.rotated(body.angle) + body.position
+                    py_y = config.HEIGHT - int(y)
+                    vertices.append((int(x), py_y))
+                if len(vertices) > 2:
+                    pygame.draw.polygon(surface, (255, 0, 0), vertices, 2)
+
         variant = getattr(body, "variant", None)
         if variant and variant in assets["blocks"]:
             img = assets["blocks"][variant]


### PR DESCRIPTION
## Summary
- show physical hitboxes in pygame renderer
- print block hitbox information when a block is created
- add simple diagnostic test to check collision of two blocks
- install requirements and run simple_stack_test to verify
- run existing unit tests

## Testing
- `python -m src.debug.simple_stack_test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863120d4c448324a83955e0c6eed44a