### PR TITLE
Use block asset for crane blocks

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -33,7 +33,13 @@ def generate_once(index: int, assets, sounds=None) -> None:
         dynamic_bodies = [b for b in space.bodies if isinstance(b, pymunk.Body) and b.body_type == pymunk.Body.DYNAMIC]
         if len(dynamic_bodies) < block_count and i % (config.FPS * config.BLOCK_DROP_INTERVAL) == 0:
             drop_x = crane_x + random.randint(*config.DROP_VARIATION_RANGE)
-            block.create_block(space, drop_x, config.HEIGHT - config.CRANE_DROP_HEIGHT, random.choice(list(assets["blocks"].keys())))
+            # Always use the main block texture instead of random variants
+            block.create_block(
+                space,
+                drop_x,
+                config.HEIGHT - config.CRANE_DROP_HEIGHT,
+                "block.png",
+            )
             events.append((t, "impact"))
         crane_x += crane_dir * crane_speed / config.FPS
         if crane_x > config.WIDTH - config.CRANE_MOVEMENT_BOUNDS:

--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -20,7 +20,8 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
 
     crane_x = config.WIDTH // 2
     drop_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
-    block_variant = next(iter(assets["blocks"]))
+    # Force usage of the main block texture for clarity
+    block_variant = "block.png"
 
     # NEW: create two blocks manually for collision diagnostics
     block1 = block.create_block(space, 540, 100, block_variant)

--- a/src/physics_sim/block.py
+++ b/src/physics_sim/block.py
@@ -6,8 +6,14 @@ import pymunk
 from .. import config
 
 
-def create_block(space: pymunk.Space, x: float, y: float, variant: str,
-                 mass: float = 5.0, size: Tuple[int, int] = (200, 100)) -> pymunk.Body:
+def create_block(
+    space: pymunk.Space,
+    x: float,
+    y: float,
+    variant: str = "block.png",
+    mass: float = 5.0,
+    size: Tuple[int, int] = (200, 100),
+) -> pymunk.Body:
     """Create a dynamic block body and add it to the space."""
     width, height = size
     moment = pymunk.moment_for_box(mass, (width, height))


### PR DESCRIPTION
## Summary
- default `block.png` for all blocks
- use `block.png` explicitly in debug script
- drop random block textures in batch video generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6863221e5c5083248c446d0d78413df2