### PR TITLE
Fix block stacking visuals

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,9 @@ HEIGHT = 1920
 FPS = 30
 DURATION = 60  # seconds
 
+# Pixel dimensions of a block sprite and its corresponding physics body
+BLOCK_SIZE = (200, 100)
+
 # Number of blocks that may be dropped in a single video
 BLOCK_COUNT_RANGE = (10, 20)
 

--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -30,7 +30,7 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
     print(f"Block1 position: {block1.position}")
     print(f"Block2 position: {block2.position}")
 
-    block_height = 100  # assuming default size
+    block_height = config.BLOCK_SIZE[1]
     for step in range(10):
         space.step(1 / config.FPS)
         print(f"Step {step}: Block1={block1.position}, Block2={block2.position}")

--- a/src/physics_sim/block.py
+++ b/src/physics_sim/block.py
@@ -12,7 +12,7 @@ def create_block(
     y: float,
     variant: str = "block.png",
     mass: float = 5.0,
-    size: Tuple[int, int] = (200, 100),
+    size: Tuple[int, int] = config.BLOCK_SIZE,
 ) -> pymunk.Body:
     """Create a dynamic block body and add it to the space."""
     width, height = size

--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -31,7 +31,10 @@ def load_assets() -> Dict[str, pygame.Surface]:
     assets["blocks"] = {}
     for file in os.listdir(config.ASSET_PATHS["block"]):
         if file.endswith(".png"):
-            assets["blocks"][file] = pygame.image.load(os.path.join(config.ASSET_PATHS["block"], file)).convert_alpha()
+            img = pygame.image.load(os.path.join(config.ASSET_PATHS["block"], file)).convert_alpha()
+            if img.get_size() != config.BLOCK_SIZE:
+                img = pygame.transform.smoothscale(img, config.BLOCK_SIZE)
+            assets["blocks"][file] = img
     return assets
 
 


### PR DESCRIPTION
## Summary
- define `BLOCK_SIZE` for consistent sprite/physics dimensions
- use `BLOCK_SIZE` when creating blocks
- scale loaded block sprites to the physics size
- update debug stack test to rely on the new constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863249015108324b22d7687db110860