### PR TITLE
Fix debug overlay and background scaling

### DIFF
--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -20,10 +20,12 @@ _DEF_FONT = None
 def load_assets() -> Dict[str, pygame.Surface]:
     """Load image assets into a dictionary."""
     assets = {}
-    assets["sky"] = {
-        name: pygame.image.load(os.path.join(config.ASSET_PATHS["sky"], name)).convert_alpha()
-        for name in config.SKY_OPTIONS
-    }
+    assets["sky"] = {}
+    for name in config.SKY_OPTIONS:
+        img = pygame.image.load(os.path.join(config.ASSET_PATHS["sky"], name)).convert_alpha()
+        if img.get_size() != (config.WIDTH, config.HEIGHT):
+            img = pygame.transform.smoothscale(img, (config.WIDTH, config.HEIGHT))
+        assets["sky"][name] = img
     assets["crane_bar"] = pygame.image.load(os.path.join(config.ASSET_PATHS["crane"], "crane_bar.png")).convert_alpha()
     assets["hook"] = pygame.image.load(os.path.join(config.ASSET_PATHS["crane"], "hook.png")).convert_alpha()
 
@@ -53,16 +55,6 @@ def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_nam
         if isinstance(body, pymunk.Body) and body.body_type != pymunk.Body.DYNAMIC:
             continue
 
-        # NEW: draw physical hitboxes in red for debug purposes
-        for shape in body.shapes:
-            if isinstance(shape, pymunk.Poly):
-                vertices = []
-                for v in shape.get_vertices():
-                    x, y = v.rotated(body.angle) + body.position
-                    py_y = config.HEIGHT - int(y)
-                    vertices.append((int(x), py_y))
-                if len(vertices) > 2:
-                    pygame.draw.polygon(surface, (255, 0, 0), vertices, 2)
 
         variant = getattr(body, "variant", None)
         if variant and variant in assets["blocks"]:


### PR DESCRIPTION
## Summary
- scale sky images to match configured resolution
- remove debug polygon overlay that showed block hitboxes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632bd3d968832485762f0edcf0021a