### PR TITLE
Rotate block assets with body orientation

### DIFF
--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -1,6 +1,7 @@
 """Headless Pygame renderer for the challenge."""
 
 from typing import Dict
+import math
 import os
 
 import pygame
@@ -40,6 +41,12 @@ def load_assets() -> Dict[str, pygame.Surface]:
     return assets
 
 
+def rotate_surface(img: pygame.Surface, angle_rad: float) -> pygame.Surface:
+    """Return a new surface rotated to match the given body angle."""
+    angle_deg = -math.degrees(angle_rad)
+    return pygame.transform.rotate(img, angle_deg)
+
+
 def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_name: str) -> np.ndarray:
     """Render a single frame and return it as a numpy array."""
     surface.blit(assets["sky"][sky_name], (0, 0))
@@ -58,7 +65,8 @@ def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_nam
 
         variant = getattr(body, "variant", None)
         if variant and variant in assets["blocks"]:
-            img = assets["blocks"][variant]
+            base_img = assets["blocks"][variant]
+            img = rotate_surface(base_img, body.angle)
             x, y = body.position
             # Convert from Pymunk's bottom-left origin to Pygame's top-left
             # coordinate system.

--- a/tests/test_pygame_renderer.py
+++ b/tests/test_pygame_renderer.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import numpy as np
 import pygame
+import math
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -22,3 +23,9 @@ def test_render_frame_shape(tmp_path):
     surface = pygame.Surface((1080, 1920))
     arr = pygame_renderer.render_frame(surface, space, assets, 540, "skyline_day.png")
     assert arr.shape[0] == 1920 and arr.shape[1] == 1080
+
+
+def test_rotate_surface_swaps_dimensions():
+    img = pygame.Surface((10, 20))
+    rotated = pygame_renderer.rotate_surface(img, math.pi / 2)
+    assert rotated.get_size() == (20, 10)


### PR DESCRIPTION
## Summary
- rotate block images to match physics bodies
- add rotate_surface helper for unit tests
- test surface rotation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632d4d6b3c8324b443abe472cd19e4