### PR TITLE
Aligner la grue en haut de la fenêtre

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -26,10 +26,14 @@ CRANE_MOVEMENT_BOUNDS = 200
 DROP_VARIATION_RANGE = (-30, 30)
 
 # Offset for the hook relative to the top of the crane bar
-HOOK_Y_OFFSET = 80
+# The crane_bar asset contains a large transparent margin above the
+# visible bar. To keep the hook 80px below the visible bar despite
+# this margin, we compensate here (394px transparent head).
+HOOK_Y_OFFSET = 474
 
-# Vertical position of the crane bar itself
-CRANE_BAR_Y = 0
+# Vertical position of the crane bar itself. We shift it upward so the
+# visible bar sits only a few pixels from the top of the window.
+CRANE_BAR_Y = -389
 
 # Delay between consecutive block drops in seconds
 BLOCK_DROP_INTERVAL = 2


### PR DESCRIPTION
## Summary
- décale la barre et le crochet de la grue pour qu'ils soient collés au haut de l'écran

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632e7f156883249590e80c8edf89fc