### PR TITLE
Randomize block textures

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -33,12 +33,12 @@ def generate_once(index: int, assets, sounds=None) -> None:
         dynamic_bodies = [b for b in space.bodies if isinstance(b, pymunk.Body) and b.body_type == pymunk.Body.DYNAMIC]
         if len(dynamic_bodies) < block_count and i % (config.FPS * config.BLOCK_DROP_INTERVAL) == 0:
             drop_x = crane_x + random.randint(*config.DROP_VARIATION_RANGE)
-            # Always use the main block texture instead of random variants
+            block_variant = random.choice(config.BLOCK_VARIANTS)
             block.create_block(
                 space,
                 drop_x,
                 config.HEIGHT - config.CRANE_DROP_HEIGHT,
-                "block.png",
+                block_variant,
             )
             events.append((t, "impact"))
         crane_x += crane_dir * crane_speed / config.FPS

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,13 @@ DURATION = 8  # seconds
 # Pixel dimensions of a block sprite and its corresponding physics body
 BLOCK_SIZE = (350, 150)
 
+# Different textures that can be used for the falling blocks
+BLOCK_VARIANTS = [
+    "block.png",
+    "block_variant1.png",
+    "block_variant2.png",
+]
+
 # Number of blocks that may be dropped in a single video
 BLOCK_COUNT_RANGE = (10, 20)
 

--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -3,6 +3,7 @@
 import os
 
 import pygame
+import random
 from pydub import AudioSegment
 
 from .. import config
@@ -20,8 +21,7 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
 
     crane_x = config.WIDTH // 2
     drop_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
-    # Force usage of the main block texture for clarity
-    block_variant = "block.png"
+    block_variant = random.choice(config.BLOCK_VARIANTS)
 
     # NEW: create two blocks manually for collision diagnostics
     block1 = block.create_block(space, 540, 100, block_variant)
@@ -45,7 +45,7 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
     frames = []
     for i in range(total_frames):
         if i in drop_frames:
-            block.create_block(space, crane_x, drop_y, block_variant)
+            block.create_block(space, crane_x, drop_y, random.choice(config.BLOCK_VARIANTS))
             print(f"Bloc créé à ({crane_x}, {drop_y})")
             print(f"Nombre de bodies: {len(space.bodies)}")
             print(f"Nombre de shapes: {len(space.shapes)}")

--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -30,14 +30,16 @@ def load_assets() -> Dict[str, pygame.Surface]:
     assets["crane_bar"] = pygame.image.load(os.path.join(config.ASSET_PATHS["crane"], "crane_bar.png")).convert_alpha()
     assets["hook"] = pygame.image.load(os.path.join(config.ASSET_PATHS["crane"], "hook.png")).convert_alpha()
 
-    # load block variants lazily
+    # load block variants defined in config
     assets["blocks"] = {}
-    for file in os.listdir(config.ASSET_PATHS["block"]):
-        if file.endswith(".png"):
-            img = pygame.image.load(os.path.join(config.ASSET_PATHS["block"], file)).convert_alpha()
-            if img.get_size() != config.BLOCK_SIZE:
-                img = pygame.transform.smoothscale(img, config.BLOCK_SIZE)
-            assets["blocks"][file] = img
+    for file in config.BLOCK_VARIANTS:
+        path = os.path.join(config.ASSET_PATHS["block"], file)
+        if not os.path.exists(path):
+            continue
+        img = pygame.image.load(path).convert_alpha()
+        if img.get_size() != config.BLOCK_SIZE:
+            img = pygame.transform.smoothscale(img, config.BLOCK_SIZE)
+        assets["blocks"][file] = img
     return assets
 
 


### PR DESCRIPTION
## Summary
- define `BLOCK_VARIANTS` in config
- load only these block images
- pick a random variant when blocks are created
- update debug script to use random textures
- include the new variant images
- remove block variant images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863c96041c08324bbf1e7b5dff6c6d4