### PR TITLE
Improve block asset randomization

### DIFF
--- a/src/debug/simple_stack_test.py
+++ b/src/debug/simple_stack_test.py
@@ -4,10 +4,12 @@ import os
 
 import pygame
 import random
+from collections import deque
 from pydub import AudioSegment
 
 from .. import config
 from ..physics_sim import block, space_builder
+from ..batch.batch_generate import choose_block_variant
 from ..renderer import pygame_renderer
 from ..video_export import moviepy_exporter
 
@@ -21,7 +23,8 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
 
     crane_x = config.WIDTH // 2
     drop_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
-    block_variant = random.choice(config.BLOCK_VARIANTS)
+    history: deque = deque(maxlen=2)
+    block_variant = choose_block_variant(config.BLOCK_VARIANTS, history)
 
     # NEW: create two blocks manually for collision diagnostics
     block1 = block.create_block(space, 540, 100, block_variant)
@@ -45,7 +48,7 @@ def run(output: str = os.path.join(config.OUTPUT_DIR, "stack_test.mp4"), seconds
     frames = []
     for i in range(total_frames):
         if i in drop_frames:
-            block.create_block(space, crane_x, drop_y, random.choice(config.BLOCK_VARIANTS))
+            block.create_block(space, crane_x, drop_y, choose_block_variant(config.BLOCK_VARIANTS, history))
             print(f"Bloc créé à ({crane_x}, {drop_y})")
             print(f"Nombre de bodies: {len(space.bodies)}")
             print(f"Nombre de shapes: {len(space.shapes)}")


### PR DESCRIPTION
## Summary
- pick block variants with a small memory to avoid long repeats
- reuse the same selection logic in the debug script

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ec3d06608324b3f0a70bb481f211