### PR TITLE
Ensure timer overlay persists throughout video

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -131,12 +131,12 @@ def generate_once(index: int, assets, sounds=None) -> None:
         elif crane_x < config.CRANE_MOVEMENT_BOUNDS:
             crane_x = config.CRANE_MOVEMENT_BOUNDS
             crane_dir = 1
-        arr = pygame_renderer.render_frame(screen, space, assets, crane_x, sky)
+        pygame_renderer.render_frame(screen, space, assets, crane_x, sky)
         overlays.draw_timer(screen, remaining)
         if i < config.FPS * 2:
             overlays.draw_intro(screen)
-            arr = pygame.surfarray.array3d(screen)
-            arr = np.transpose(arr, (1, 0, 2))
+        arr = pygame.surfarray.array3d(screen)
+        arr = np.transpose(arr, (1, 0, 2))
         frames.append(arr)
     if state is None:
         state = "fail"


### PR DESCRIPTION
## Summary
- capture the timer overlay in every frame

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f2e82f148324a0a286e9951a6779