### PR TITLE
Add intro screen customization

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -79,6 +79,15 @@ def generate_once(index: int, assets, sounds=None) -> None:
         handler.post_solve = log_impact
 
     variant_history: deque = deque(maxlen=2)
+
+    # Render a short intro sequence before starting the simulation
+    for _ in range(config.INTRO_DURATION * config.FPS):
+        pygame_renderer.render_frame(screen, space, assets, crane_x, sky)
+        overlays.draw_intro(screen)
+        arr = pygame.surfarray.array3d(screen)
+        arr = np.transpose(arr, (1, 0, 2))
+        frames.append(arr)
+
     for i in range(config.TIME_LIMIT * config.FPS):
         t = i / config.FPS
         remaining = config.TIME_LIMIT - t
@@ -133,8 +142,6 @@ def generate_once(index: int, assets, sounds=None) -> None:
             crane_dir = 1
         pygame_renderer.render_frame(screen, space, assets, crane_x, sky)
         overlays.draw_timer(screen, remaining)
-        if i < config.FPS * 2:
-            overlays.draw_intro(screen)
         arr = pygame.surfarray.array3d(screen)
         arr = np.transpose(arr, (1, 0, 2))
         frames.append(arr)
@@ -157,7 +164,7 @@ def generate_once(index: int, assets, sounds=None) -> None:
         arr = np.transpose(arr, (1, 0, 2))
         frames.append(arr)
 
-    duration = config.TIME_LIMIT + 2
+    duration = config.INTRO_DURATION + config.TIME_LIMIT + 2
     if sounds:
         audio = sound_manager.mix_tracks(duration, events, sounds)
     else:

--- a/src/config.py
+++ b/src/config.py
@@ -5,10 +5,13 @@ import os
 WIDTH = 1080
 HEIGHT = 1920
 FPS = 30
-DURATION = 32  # seconds
+# Duration of the initial intro screen shown before the simulation starts
+INTRO_DURATION = 3  # seconds
 # Number of seconds before the challenge ends. If the tower has not
 # reached the required height after this duration, the run is a failure.
 TIME_LIMIT = 30
+# Total clip duration used when exporting the final video
+DURATION = INTRO_DURATION + TIME_LIMIT + 2
 
 # Pixel dimensions of a block sprite and its corresponding physics body
 BLOCK_SIZE = (350, 150)
@@ -55,6 +58,17 @@ PALETTES = {
         "text": (255, 255, 255),
         "shadow": (0, 0, 0),
     }
+}
+
+# Text shown at the beginning of the video and its styling options
+INTRO_TEXT = "PEUT-IL FINIR CETTE TOUR EN 60s ?"
+INTRO_STYLE = {
+    "font_size": 120,
+    # Vertical position of the text. A value closer to 0 means higher on screen
+    "y_pos": HEIGHT // 4,
+    "shadow_offset": (4, 4),
+    # Palette key used for text and shadow colors
+    "palette": "default",
 }
 
 # Sky backgrounds available in assets/sky

--- a/src/renderer/overlays.py
+++ b/src/renderer/overlays.py
@@ -8,14 +8,23 @@ from .. import config
 
 pygame.font.init()
 
-def draw_intro(surface: pygame.Surface, text: str = "PEUT-IL FINIR CETTE TOUR EN 60s ?") -> None:
-    """Draw an intro overlay text on the given surface."""
-    font = pygame.font.Font(None, 72)
-    rendered = font.render(text, True, config.PALETTES["default"]["text"])
-    shadow = font.render(text, True, config.PALETTES["default"]["shadow"])
+
+def draw_intro(surface: pygame.Surface, text: str | None = None) -> None:
+    """Draw the intro text using the style defined in :mod:`config`."""
+    if text is None:
+        text = config.INTRO_TEXT
+    style = config.INTRO_STYLE
+    font = pygame.font.Font(None, style.get("font_size", 72))
+    font.set_bold(True)
+    palette = config.PALETTES.get(style.get("palette", "default"), {})
+    text_color = palette.get("text", (255, 255, 255))
+    shadow_color = palette.get("shadow", (0, 0, 0))
+    rendered = font.render(text, True, text_color)
+    shadow = font.render(text, True, shadow_color)
     x = (config.WIDTH - rendered.get_width()) // 2
-    y = config.HEIGHT // 3
-    surface.blit(shadow, (x + 2, y + 2))
+    y = style.get("y_pos", config.HEIGHT // 3)
+    dx, dy = style.get("shadow_offset", (2, 2))
+    surface.blit(shadow, (x + dx, y + dy))
     surface.blit(rendered, (x, y))
 
 


### PR DESCRIPTION
## Summary
- configure intro text & style via `config.py`
- display intro 3s before animation starts
- render intro using configurable style
- adjust total duration handling

## Testing
- `pip install numpy pygame pymunk moviepy pydub`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f5b19ae08324865177e25c6a3173