### PR TITLE
Add intro palettes

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -53,11 +53,69 @@ CRANE_BAR_Y = -389
 BLOCK_DROP_INTERVAL = 2
 
 # Available color palettes for overlays or effects
+# "timer" is identical to the countdown timer colors. Additional palettes can be
+# used for styling the intro text with various looks.
 PALETTES = {
     "default": {
         "text": (255, 255, 255),
         "shadow": (0, 0, 0),
-    }
+    },
+    # Same white text with black shadow as the timer
+    "timer": {
+        "text": (255, 255, 255),
+        "shadow": (0, 0, 0),
+    },
+    # Green on black retro computer style
+    "retro": {
+        "text": (0, 255, 0),
+        "shadow": (0, 0, 0),
+    },
+    # Magenta text with cyan shadow for a neon effect
+    "neon": {
+        "text": (255, 0, 255),
+        "shadow": (0, 255, 255),
+    },
+    # Yellow text with dark blue shadow reminiscent of comic books
+    "comic": {
+        "text": (255, 255, 0),
+        "shadow": (0, 0, 128),
+    },
+}
+
+# Predefined intro styles combining fonts, colors and shadow offsets
+INTRO_STYLES = {
+    # Matches the countdown timer appearance
+    "timer": {
+        "font_name": None,  # default font
+        "font_size": 120,
+        "y_pos": HEIGHT // 4,
+        "shadow_offset": (2, 2),
+        "palette": "timer",
+    },
+    # A green retro terminal look
+    "retro": {
+        "font_name": "courier",
+        "font_size": 100,
+        "y_pos": HEIGHT // 4,
+        "shadow_offset": (4, 4),
+        "palette": "retro",
+    },
+    # Bright neon colors with a larger shadow
+    "neon": {
+        "font_name": "arial",
+        "font_size": 110,
+        "y_pos": HEIGHT // 4,
+        "shadow_offset": (6, 6),
+        "palette": "neon",
+    },
+    # Comic style using Comic Sans and contrasting shadow
+    "comic": {
+        "font_name": "comicsansms",
+        "font_size": 120,
+        "y_pos": HEIGHT // 4,
+        "shadow_offset": (5, 5),
+        "palette": "comic",
+    },
 }
 
 # Text shown at the beginning of the video and its styling options

--- a/src/renderer/overlays.py
+++ b/src/renderer/overlays.py
@@ -9,12 +9,23 @@ from .. import config
 pygame.font.init()
 
 
-def draw_intro(surface: pygame.Surface, text: str | None = None) -> None:
-    """Draw the intro text using the style defined in :mod:`config`."""
+def draw_intro(surface: pygame.Surface, text: str | None = None, style_name: str | None = None) -> None:
+    """Draw the intro text using the style defined in :mod:`config`.
+
+    ``style_name`` can be one of the keys defined in ``config.INTRO_STYLES`` to
+    pick an alternate appearance.
+    """
     if text is None:
         text = config.INTRO_TEXT
-    style = config.INTRO_STYLE
-    font = pygame.font.Font(None, style.get("font_size", 72))
+    if style_name is not None:
+        style = config.INTRO_STYLES.get(style_name, config.INTRO_STYLE)
+    else:
+        style = config.INTRO_STYLE
+    font_name = style.get("font_name")
+    if font_name:
+        font = pygame.font.SysFont(font_name, style.get("font_size", 72))
+    else:
+        font = pygame.font.Font(None, style.get("font_size", 72))
     font.set_bold(True)
     palette = config.PALETTES.get(style.get("palette", "default"), {})
     text_color = palette.get("text", (255, 255, 255))


### PR DESCRIPTION
## Summary
- add multiple color palettes and font presets for intro text
- allow `draw_intro` to select a palette by name and use custom fonts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863ffc9c09c8324ae824b2ef5ba2c01