### PR TITLE
Fix despawn of tilted blocks

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -158,8 +158,18 @@ def generate_once(index: int, assets, sounds=None) -> None:
             bb = list(body.shapes)[0].bb
             return bb.bottom <= config.FLOOR_Y + 1
 
+        def _is_tilted(body):
+            angle = abs(body.angle % math.pi)
+            if angle > math.pi / 2:
+                angle = math.pi - angle
+            return angle > config.BLOCK_SIDE_ANGLE
+
         for b in resting:
-            if b is first_block or not _is_on_floor(b) or _has_block_on_top(b):
+            if (
+                b is first_block
+                or (not _is_on_floor(b) and not _is_tilted(b))
+                or _has_block_on_top(b)
+            ):
                 unsupported[b] = 0.0
                 continue
 

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,11 @@ BLOCK_SIZE = (350, 150)
 # remains before disappearing through the floor (seconds)
 BLOCK_DESPAWN_DELAY = 4
 
+# Angle (in radians) beyond which a resting block is considered to be
+# "on its side" and should be removed after ``BLOCK_DESPAWN_DELAY``
+# if unsupported.
+BLOCK_SIDE_ANGLE = 0.4
+
 # Vertical position of the floor segment used in the physics space
 FLOOR_Y = 10
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,3 +12,4 @@ def test_basic_constants():
     assert config.BLOCK_DROP_INTERVAL > 0
     assert 0 <= config.BLOCK_DROP_JITTER < config.BLOCK_DROP_INTERVAL
     assert config.BLOCK_DESPAWN_DELAY > 0
+    assert config.BLOCK_SIDE_ANGLE > 0


### PR DESCRIPTION
## Summary
- mark blocks on their side for removal
- expose new `BLOCK_SIDE_ANGLE` config
- test the new constant

## Testing
- `pip install -q pygame pymunk moviepy pydub numpy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864290ae13c832490d03c8738d8379c