### PR TITLE
Add preview block rendering

### DIFF
--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -49,8 +49,21 @@ def rotate_surface(img: pygame.Surface, angle_rad: float) -> pygame.Surface:
     return pygame.transform.rotate(img, angle_deg)
 
 
-def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_name: str) -> np.ndarray:
-    """Render a single frame and return it as a numpy array."""
+def render_frame(
+    surface: pygame.Surface,
+    space,
+    assets,
+    crane_x: float,
+    sky_name: str,
+    preview_variant: str | None = None,
+) -> np.ndarray:
+    """Render a single frame and return it as a numpy array.
+
+    ``preview_variant`` optionally specifies the block variant currently hanging
+    from the crane hook ready to be dropped. When provided, the corresponding
+    sprite is drawn beneath the hook so the upcoming block is visible to the
+    viewer.
+    """
     surface.blit(assets["sky"][sky_name], (0, 0))
     bar_img = assets["crane_bar"]
     if bar_img.get_width() != config.WIDTH:
@@ -60,6 +73,12 @@ def render_frame(surface: pygame.Surface, space, assets, crane_x: float, sky_nam
     hook_img = assets["hook"]
     hook_y = config.CRANE_BAR_Y + config.HOOK_Y_OFFSET
     surface.blit(hook_img, (crane_x - hook_img.get_width() // 2, hook_y))
+    if preview_variant and preview_variant in assets["blocks"]:
+        preview_img = assets["blocks"][preview_variant]
+        # Position the preview so its top touches the bottom of the hook.
+        preview_x = crane_x - preview_img.get_width() // 2
+        preview_y = hook_y + hook_img.get_height() - 5
+        surface.blit(preview_img, (preview_x, preview_y))
     for body in space.bodies:
         if isinstance(body, pymunk.Body) and body.body_type != pymunk.Body.DYNAMIC:
             continue

--- a/tests/test_pygame_renderer.py
+++ b/tests/test_pygame_renderer.py
@@ -21,7 +21,9 @@ def test_render_frame_shape(tmp_path):
     space = space_builder.init_space()
     block.create_block(space, 540, 100, "block.png")
     surface = pygame.Surface((1080, 1920))
-    arr = pygame_renderer.render_frame(surface, space, assets, 540, "skyline_day.png")
+    arr = pygame_renderer.render_frame(
+        surface, space, assets, 540, "skyline_day.png", "block.png"
+    )
     assert arr.shape[0] == 1920 and arr.shape[1] == 1080
 
 


### PR DESCRIPTION
## Summary
- preview next block in crane hook
- use same variant when spawned
- adjust renderer API and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647f8f67f08324a1c06722c3a61858