### PR TITLE
Update preview block position and visibility

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -85,6 +85,8 @@ def generate_once(index: int, assets, sounds=None) -> None:
 
     variant_history: deque = deque(maxlen=2)
     preview_variant = choose_block_variant(config.BLOCK_VARIANTS, variant_history)
+    # Time until which the preview should remain hidden after a drop
+    preview_hidden_until = 0.0
     unsupported: dict[pymunk.Body, float] = {}
     falling_blocks: set[pymunk.Body] = set()
     first_block: pymunk.Body | None = None
@@ -123,6 +125,7 @@ def generate_once(index: int, assets, sounds=None) -> None:
             )
             delay = max(0.5, delay)
             next_drop_time = t + delay
+            preview_hidden_until = t + config.PREVIEW_HIDE_DURATION
             preview_variant = choose_block_variant(
                 config.BLOCK_VARIANTS,
                 variant_history,
@@ -211,7 +214,8 @@ def generate_once(index: int, assets, sounds=None) -> None:
         elif crane_x < config.CRANE_MOVEMENT_BOUNDS:
             crane_x = config.CRANE_MOVEMENT_BOUNDS
             crane_dir = 1
-        pygame_renderer.render_frame(screen, space, assets, crane_x, sky, preview_variant)
+        show_preview = preview_variant if t >= preview_hidden_until else None
+        pygame_renderer.render_frame(screen, space, assets, crane_x, sky, show_preview)
         overlays.draw_timer(screen, remaining)
         arr = pygame.surfarray.array3d(screen)
         arr = np.transpose(arr, (1, 0, 2))

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,14 @@ GRUE_SPEED_RANGE = (80, 120)
 
 # Height from the bottom of the screen where blocks are spawned
 CRANE_DROP_HEIGHT = 580
+# Height from the bottom of the screen where the preview of the next block
+# should be displayed.  By default it matches ``CRANE_DROP_HEIGHT`` so the
+# preview appears exactly where blocks will spawn.
+PREVIEW_HEIGHT = CRANE_DROP_HEIGHT
+
+# Duration in seconds during which the preview is hidden after a block is
+# spawned.  This avoids permanently showing a block on screen.
+PREVIEW_HIDE_DURATION = 1.0
 
 # Horizontal margin used for crane movement limits
 CRANE_MOVEMENT_BOUNDS = 340

--- a/src/renderer/pygame_renderer.py
+++ b/src/renderer/pygame_renderer.py
@@ -75,9 +75,10 @@ def render_frame(
     surface.blit(hook_img, (crane_x - hook_img.get_width() // 2, hook_y))
     if preview_variant and preview_variant in assets["blocks"]:
         preview_img = assets["blocks"][preview_variant]
-        # Position the preview so its top touches the bottom of the hook.
+        # Center the preview on the configured preview height so it matches
+        # the spawn position of new blocks.
         preview_x = crane_x - preview_img.get_width() // 2
-        preview_y = hook_y + hook_img.get_height() - 5
+        preview_y = config.PREVIEW_HEIGHT - preview_img.get_height() // 2
         surface.blit(preview_img, (preview_x, preview_y))
     for body in space.bodies:
         if isinstance(body, pymunk.Body) and body.body_type != pymunk.Body.DYNAMIC:


### PR DESCRIPTION
## Summary
- add preview position and cooldown settings
- align preview block with spawn location
- hide preview for a short duration after each drop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648415e0348324918e3a85ebd8b312