### PR TITLE
Add horizontal momentum to falling blocks

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -111,11 +111,13 @@ def generate_once(index: int, assets, sounds=None) -> None:
             prev_second = secs
         if state is None and t >= next_drop_time:
             drop_x = crane_x + random.randint(*config.DROP_VARIATION_RANGE)
+            initial_vx = crane_dir * crane_speed * config.DROP_HORIZONTAL_SPEED_FACTOR
             new_block = block.create_block(
                 space,
                 drop_x,
                 config.HEIGHT - config.CRANE_DROP_HEIGHT,
                 preview_variant,
+                initial_velocity=(initial_vx, 0.0),
             )
             if first_block is None:
                 first_block = new_block

--- a/src/config.py
+++ b/src/config.py
@@ -54,6 +54,11 @@ BLOCK_COUNT_RANGE = (10, 20)
 # Speed of the moving crane in pixels per second
 GRUE_SPEED_RANGE = (80, 120)
 
+# Fraction of the crane's horizontal velocity transferred to a block when it
+# is dropped. A value of 1.0 means the block starts with the same horizontal
+# speed as the hook, while 0 would spawn it without sideways momentum.
+DROP_HORIZONTAL_SPEED_FACTOR = 1.0
+
 # Height from the bottom of the screen where blocks are spawned
 CRANE_DROP_HEIGHT = 580
 # Height from the bottom of the screen where the preview of the next block

--- a/src/physics_sim/block.py
+++ b/src/physics_sim/block.py
@@ -13,12 +13,14 @@ def create_block(
     variant: str = "block.png",
     mass: float = 5.0,
     size: Tuple[int, int] = config.BLOCK_SIZE,
+    initial_velocity: Tuple[float, float] = (0.0, 0.0),
 ) -> pymunk.Body:
     """Create a dynamic block body and add it to the space."""
     width, height = size
     moment = pymunk.moment_for_box(mass, (width, height))
     body = pymunk.Body(mass, moment)
     body.position = x, y
+    body.velocity = initial_velocity
     shape = pymunk.Poly.create_box(body, (width, height))
 
     # NEW: debug logs for hitbox


### PR DESCRIPTION
## Summary
- preserve a portion of the crane movement on drop
- support initial velocity when creating blocks
- expose DROP_HORIZONTAL_SPEED_FACTOR constant

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864872295548324ba56886ed9811bbb