### PR TITLE
Add toggle to disable block despawn

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -188,7 +188,10 @@ def generate_once(index: int, assets, sounds=None) -> None:
                 continue
 
             unsupported[b] = unsupported.get(b, 0.0) + 1 / config.FPS
-            if unsupported[b] >= config.BLOCK_DESPAWN_DELAY:
+            if (
+                config.BLOCK_DESPAWN_ENABLED
+                and unsupported[b] >= config.BLOCK_DESPAWN_DELAY
+            ):
                 for s in b.shapes:
                     s.sensor = True
                 b.velocity = (0, -300)

--- a/src/config.py
+++ b/src/config.py
@@ -19,6 +19,9 @@ BLOCK_SIZE = (150, 220)
 # Time a resting block without another block placed on top
 # remains before disappearing through the floor (seconds)
 BLOCK_DESPAWN_DELAY = 3
+# Toggle automatic removal of unsupported blocks. When set to ``False`` the
+# despawn logic is skipped and all blocks remain present.
+BLOCK_DESPAWN_ENABLED = True
 
 # Angle (in radians) beyond which a resting block is considered to be
 # "on its side" and should be removed after ``BLOCK_DESPAWN_DELAY``

--- a/tests/test_block_despawn.py
+++ b/tests/test_block_despawn.py
@@ -85,3 +85,81 @@ def test_only_first_block_remains_on_floor():
     remaining = [b for b in space.bodies if b.body_type == pymunk.Body.DYNAMIC]
     assert first_block in remaining
     assert second not in remaining
+
+
+def test_despawn_can_be_disabled():
+    original = config.BLOCK_DESPAWN_ENABLED
+    config.BLOCK_DESPAWN_ENABLED = False
+    try:
+        space = space_builder.init_space()
+        spawn_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
+
+        first = block.create_block(space, 100, spawn_y)
+        second = block.create_block(space, 400, spawn_y)
+
+        unsupported = {}
+        falling = set()
+        first_block = first
+
+        def _has_block_on_top(body, bodies):
+            bb = list(body.shapes)[0].bb
+            for other in bodies:
+                if other is body:
+                    continue
+                obb = list(other.shapes)[0].bb
+                if (
+                    obb.bottom > bb.top - 5
+                    and obb.bottom < bb.top + config.BLOCK_SIZE[1] / 2
+                    and obb.right > bb.left + 10
+                    and obb.left < bb.right - 10
+                ):
+                    return True
+            return False
+
+        def _is_on_floor(body):
+            bb = list(body.shapes)[0].bb
+            return bb.bottom <= config.FLOOR_Y + 5
+
+        def _is_tilted(body):
+            angle = abs(body.angle % math.pi)
+            if angle > math.pi / 2:
+                angle = math.pi - angle
+            return angle > config.BLOCK_SIDE_ANGLE
+
+        total_steps = int(config.FPS * (config.BLOCK_DESPAWN_DELAY + 4))
+        for _ in range(total_steps):
+            space.step(1 / config.FPS)
+            dynamic = [b for b in space.bodies if b.body_type == pymunk.Body.DYNAMIC]
+            resting = [b for b in dynamic if abs(b.velocity.y) < 1]
+            for b in resting:
+                protected_first = (
+                    b is first_block
+                    and _is_on_floor(b)
+                    and not _has_block_on_top(b, dynamic)
+                )
+                if (
+                    protected_first
+                    or (not _is_on_floor(b) and not _is_tilted(b))
+                    or _has_block_on_top(b, dynamic)
+                ):
+                    unsupported[b] = 0.0
+                    continue
+
+                unsupported[b] = unsupported.get(b, 0.0) + 1 / config.FPS
+                if config.BLOCK_DESPAWN_ENABLED and unsupported[b] >= config.BLOCK_DESPAWN_DELAY:
+                    for s in b.shapes:
+                        s.sensor = True
+                    b.velocity = (0, -300)
+                    falling.add(b)
+
+            for b in list(falling):
+                if b.position.y < -config.BLOCK_SIZE[1]:
+                    space.remove(b, *b.shapes)
+                    falling.remove(b)
+                    unsupported.pop(b, None)
+
+        remaining = [b for b in space.bodies if b.body_type == pymunk.Body.DYNAMIC]
+        assert first_block in remaining
+        assert second in remaining
+    finally:
+        config.BLOCK_DESPAWN_ENABLED = original

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,5 +12,6 @@ def test_basic_constants():
     assert config.BLOCK_DROP_INTERVAL > 0
     assert 0 <= config.BLOCK_DROP_JITTER < config.BLOCK_DROP_INTERVAL
     assert config.BLOCK_DESPAWN_DELAY > 0
+    assert isinstance(config.BLOCK_DESPAWN_ENABLED, bool)
     assert config.BLOCK_SIDE_ANGLE > 0
     assert config.BLOCK_ADHESION_FORCE >= 0


### PR DESCRIPTION
## Summary
- make block despawning optional with `BLOCK_DESPAWN_ENABLED`
- condition despawn logic on this config value
- test the configuration option works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648a59624c8324a91708e022720029