### PR TITLE
Add crane speed scale and cleanup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ selon vos besoins.
 Un paramètre `BLOCK_DROP_JITTER` permet également d'introduire une légère
 variabilité dans l'intervalle entre deux chutes de bloc pour rendre l'action
 moins prévisible.
-De nouveaux paramètres `CRANE_OSC_*` contrôlent l'amplitude et la vitesse du
-mouvement sinusoïdal de la grue.
+Les constantes `CRANE_OSC_*` définissent l'amplitude et la fréquence du
+mouvement sinusoïdal de la grue, tandis que `CRANE_OSC_SPEED_SCALE` permet
+d'en ajuster facilement la vitesse moyenne.
 
 ### Test d'empilage simple
 

--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -95,7 +95,10 @@ def generate_once(
         phase = 0.0
     else:
         amplitude = rng.uniform(*config.CRANE_OSC_AMPLITUDE_RANGE)
-        frequency = rng.uniform(*config.CRANE_OSC_FREQUENCY_RANGE)
+        frequency = (
+            rng.uniform(*config.CRANE_OSC_FREQUENCY_RANGE)
+            * config.CRANE_OSC_SPEED_SCALE
+        )
         phase = rng.uniform(*config.CRANE_OSC_PHASE_RANGE)
     spawn_y = config.HEIGHT - config.CRANE_DROP_HEIGHT
     state = None  # "victory" or "fail"

--- a/src/config.py
+++ b/src/config.py
@@ -79,11 +79,6 @@ BLOCK_VARIANTS = [
     "block_variant3.png",
 ]
 
-# Nombre de blocs pouvant être lâchés durant une vidéo
-BLOCK_COUNT_RANGE = (10, 20)
-
-# Vitesse de déplacement de la grue en pixels/seconde
-GRUE_SPEED_RANGE = (80, 120)
 
 # Fraction de la vitesse horizontale de la grue transmise au bloc lors du
 # lâcher. 1.0 signifie que le bloc démarre avec la même vitesse horizontale que
@@ -111,6 +106,9 @@ CRANE_OSC_AMPLITUDE_RANGE = (
 )
 CRANE_OSC_FREQUENCY_RANGE = (0.4, 0.8)
 CRANE_OSC_PHASE_RANGE = (0.0, 2 * math.pi)
+# Facteur global appliqué à la fréquence pour accélérer ou ralentir
+# le mouvement de la grue sans modifier son amplitude.
+CRANE_OSC_SPEED_SCALE = 1.0
 
 # Variation aléatoire appliquée à la position X du lâcher
 DROP_VARIATION_RANGE = (-10, 10)


### PR DESCRIPTION
## Summary
- remove unused config constants
- allow tuning crane oscillation speed via `CRANE_OSC_SPEED_SCALE`
- document the new setting in the README

## Testing
- `pip install pygame pymunk numpy moviepy pydub pytest --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c61d1fd08324a4649afa7e72b831