### PR TITLE
Ensure batch cleanup of resources

### DIFF
--- a/src/batch/batch_generate.py
+++ b/src/batch/batch_generate.py
@@ -5,6 +5,7 @@ import os
 import random
 import math
 from collections import deque
+import gc
 
 
 def choose_block_variant(variants, history: deque) -> str:
@@ -38,6 +39,9 @@ from ..video_export import moviepy_exporter
 def generate_once(index: int, assets, sounds=None) -> None:
     """Generate a single video with random parameters."""
     os.makedirs(config.OUTPUT_DIR, exist_ok=True)
+    # Reinitialise Pygame at the start of each run to ensure a clean state
+    pygame.init()
+    pygame.display.set_mode((1, 1))
     space = space_builder.init_space()
     screen = pygame.Surface((config.WIDTH, config.HEIGHT))
     frames = []
@@ -242,6 +246,9 @@ def generate_once(index: int, assets, sounds=None) -> None:
         audio = AudioSegment.silent(duration=duration * 1000)
     output = os.path.join(config.OUTPUT_DIR, f"run_{index}.mp4")
     moviepy_exporter.export_video(frames, audio, output)
+    # Free Pygame resources and collected memory before the next run
+    pygame.quit()
+    gc.collect()
 
 
 def main(count: int, with_audio: bool = True) -> None:

--- a/src/video_export/moviepy_exporter.py
+++ b/src/video_export/moviepy_exporter.py
@@ -24,8 +24,13 @@ def export_video(frames: List[np.ndarray], audio, output_path: str, fps: int = c
         audio.export(temp_wav.name, format="wav")
         audio_clip = AudioFileClip(temp_wav.name)
         try:
-            clip = clip.set_audio(audio_clip)
-        except AttributeError:  # MoviePy >=2.1 uses ``with_audio``
-            clip = clip.with_audio(audio_clip)  # pragma: no cover
-        clip.write_videofile(output_path, codec="libx264", audio_codec="aac")
+            try:
+                clip = clip.set_audio(audio_clip)
+            except AttributeError:  # MoviePy >=2.1 uses ``with_audio``
+                clip = clip.with_audio(audio_clip)  # pragma: no cover
+            clip.write_videofile(output_path, codec="libx264", audio_codec="aac")
+        finally:
+            # Explicitly free MoviePy resources before returning
+            audio_clip.close()
+            clip.close()
     os.unlink(temp_wav.name)


### PR DESCRIPTION
## Summary
- restart pygame each run to avoid memory accumulation
- explicitly close moviepy clips after exporting
- clean up pygame and collect garbage after each run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659b890fb083248100d4bc2a0ab199