### PR TITLE
Run batch jobs in isolated subprocesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ vidéos produire en appelant directement le script :
 python src/batch/batch_generate.py --count 5
 ```
 
+Chaque vidéo est générée dans un sous‑processus distinct pour éviter
+l'accumulation de mémoire. Utilisez `--no-subprocess` pour revenir à
+l'ancien comportement si besoin.
+
 Vous pouvez désactiver la bande son avec l'option `--no-audio` :
 
 ```bash


### PR DESCRIPTION
## Summary
- run each video generation in its own subprocess
- allow disabling subprocess spawning via `--no-subprocess`
- document new behaviour in README

## Testing
- `ruff format src/batch/batch_generate.py`
- `ruff check src/batch/batch_generate.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a17f33cc8324b09f422d71013b4d