### PR TITLE
Implement intro text effects

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -121,6 +121,7 @@ INTRO_STYLES = {
         "y_pos": HEIGHT // 4,
         "shadow_offset": (2, 2),
         "palette": "timer",
+        "effect": "flat",
     },
     # A green retro terminal look
     "retro": {
@@ -129,6 +130,7 @@ INTRO_STYLES = {
         "y_pos": HEIGHT // 4,
         "shadow_offset": (4, 4),
         "palette": "retro",
+        "effect": "vintage",
     },
     # Bright neon colors with a larger shadow
     "neon": {
@@ -137,6 +139,7 @@ INTRO_STYLES = {
         "y_pos": HEIGHT // 4,
         "shadow_offset": (6, 6),
         "palette": "neon",
+        "effect": "neon",
     },
     # Comic style using Comic Sans and contrasting shadow
     "comic": {
@@ -145,6 +148,7 @@ INTRO_STYLES = {
         "y_pos": HEIGHT // 4,
         "shadow_offset": (5, 5),
         "palette": "comic",
+        "effect": "flat",
     },
 }
 
@@ -157,6 +161,7 @@ INTRO_STYLE = {
     "shadow_offset": (4, 4),
     # Palette key used for text and shadow colors
     "palette": "neon",
+    "effect": "neon",
 }
 
 # Sky backgrounds available in assets/sky

--- a/src/renderer/overlays.py
+++ b/src/renderer/overlays.py
@@ -2,12 +2,111 @@
 
 import pygame
 import math
+import numpy as np
 
 from .. import config
 
 
 pygame.font.init()
 
+
+def render_flat_text(
+    surface: pygame.Surface,
+    text: str,
+    font: pygame.font.Font,
+    text_color,
+    shadow_color,
+    x: int,
+    y: int,
+    dx: int,
+    dy: int,
+) -> None:
+    """Render clean text with a short drop shadow."""
+
+    rendered = font.render(text, True, text_color)
+    shadow = font.render(text, True, shadow_color)
+    surface.blit(shadow, (x + dx, y + dy))
+    surface.blit(rendered, (x, y))
+
+
+def render_neon_text(
+    surface: pygame.Surface,
+    text: str,
+    font: pygame.font.Font,
+    text_color,
+    shadow_color,
+    x: int,
+    y: int,
+    dx: int,
+    dy: int,
+) -> None:
+    """Render bright neon text with an additive glow."""
+
+    rendered = font.render(text, True, text_color)
+    center = (x + rendered.get_width() // 2, y + rendered.get_height() // 2)
+
+    for i, scale in enumerate((1.2, 1.4, 1.6)):
+        glow = font.render(text, True, text_color)
+        glow = pygame.transform.smoothscale(
+            glow,
+            (
+                int(glow.get_width() * scale),
+                int(glow.get_height() * scale),
+            ),
+        )
+        glow.set_alpha(100 // (i + 1))
+        rect = glow.get_rect(center=center)
+        surface.blit(glow, rect.topleft, special_flags=pygame.BLEND_RGBA_ADD)
+
+    shadow = font.render(text, True, shadow_color)
+    surface.blit(shadow, (x + dx, y + dy))
+    surface.blit(rendered, (x, y))
+
+
+def render_vintage_text(
+    surface: pygame.Surface,
+    text: str,
+    font: pygame.font.Font,
+    text_color,
+    shadow_color,
+    x: int,
+    y: int,
+    dx: int,
+    dy: int,
+) -> None:
+    """Render text with a warm retro look."""
+
+    rendered = font.render(text, True, text_color)
+    shadow = font.render(text, True, shadow_color)
+
+    soft = pygame.transform.smoothscale(
+        shadow,
+        (int(shadow.get_width() * 1.1), int(shadow.get_height() * 1.1)),
+    )
+    soft.set_alpha(120)
+    surface.blit(soft, (x + dx * 3, y + dy * 3))
+    surface.blit(shadow, (x + dx, y + dy))
+
+    width, height = rendered.get_size()
+
+    dark_grad = pygame.Surface((width, height), pygame.SRCALPHA)
+    for i in range(height):
+        alpha = int(60 * i / height)
+        pygame.draw.line(dark_grad, (0, 0, 0, alpha), (0, i), (width, i))
+    rendered.blit(dark_grad, (0, 0), special_flags=pygame.BLEND_RGBA_SUB)
+
+    light_grad = pygame.Surface((width, height), pygame.SRCALPHA)
+    for i in range(height):
+        alpha = int(30 * (1 - i / height))
+        pygame.draw.line(light_grad, (255, 255, 255, alpha), (0, i), (width, i))
+    rendered.blit(light_grad, (0, 0), special_flags=pygame.BLEND_RGBA_ADD)
+
+    noise = pygame.Surface((width, height), pygame.SRCALPHA)
+    arr = np.random.randint(0, 30, (height, width)).astype(np.uint8)
+    pygame.surfarray.pixels_alpha(noise)[:, :] = arr
+    rendered.blit(noise, (0, 0), special_flags=pygame.BLEND_RGBA_SUB)
+
+    surface.blit(rendered, (x, y))
 
 def draw_intro(surface: pygame.Surface, text: str | None = None, style_name: str | None = None) -> None:
     """Draw the intro text using the style defined in :mod:`config`.
@@ -30,13 +129,17 @@ def draw_intro(surface: pygame.Surface, text: str | None = None, style_name: str
     palette = config.PALETTES.get(style.get("palette", "default"), {})
     text_color = palette.get("text", (255, 255, 255))
     shadow_color = palette.get("shadow", (0, 0, 0))
-    rendered = font.render(text, True, text_color)
-    shadow = font.render(text, True, shadow_color)
-    x = (config.WIDTH - rendered.get_width()) // 2
+    width, height = font.size(text)
+    x = (config.WIDTH - width) // 2
     y = style.get("y_pos", config.HEIGHT // 3)
     dx, dy = style.get("shadow_offset", (2, 2))
-    surface.blit(shadow, (x + dx, y + dy))
-    surface.blit(rendered, (x, y))
+    effect = style.get("effect", "flat")
+    if effect == "neon":
+        render_neon_text(surface, text, font, text_color, shadow_color, x, y, dx, dy)
+    elif effect == "vintage":
+        render_vintage_text(surface, text, font, text_color, shadow_color, x, y, dx, dy)
+    else:
+        render_flat_text(surface, text, font, text_color, shadow_color, x, y, dx, dy)
 
 
 def _draw_centered(surface: pygame.Surface, text: str, color, size: int = 96) -> None:


### PR DESCRIPTION
## Summary
- add `effect` property to intro styles
- implement `render_flat_text`, `render_neon_text`, and `render_vintage_text`
- dispatch `draw_intro` rendering according to configured effect

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b330f4d483248da11512833c331e