### PR TITLE
Add victory music logic and sound toggles

### DIFF
--- a/src/audio/sound_manager.py
+++ b/src/audio/sound_manager.py
@@ -19,23 +19,35 @@ def load_sounds() -> Dict[str, AudioSegment]:
 
 def mix_tracks(duration: int, events: List[Tuple[float, str]], sounds: Dict[str, AudioSegment]) -> AudioSegment:
     """Create a mixed soundtrack using the provided events."""
+    victory_ts = next((ts for ts, name in events if name == "victory"), None)
+
+    track = AudioSegment.silent(duration=duration * 1000)
+
     base = sounds.get("bpm_loop", AudioSegment.silent(duration=duration * 1000))
-    loops = int((duration * 1000) / len(base)) + 1
-    backing = base * loops
-    track = backing[: duration * 1000]
+    if config.SOUND_ENABLED.get("bpm_loop", True):
+        loops = int((duration * 1000) / len(base)) + 1
+        backing = base * loops
+        end = duration * 1000 if victory_ts is None else int(victory_ts * 1000)
+        track = track.overlay(backing[:end], position=0)
+
     impact_variants = [n for n in sounds if n.startswith("impact")]
     prev_impact: str | None = None
     for ts, name in events:
-        segment = None
+        to_play: List[str] = []
         if name == "impact" and impact_variants:
             options = impact_variants.copy()
             if prev_impact in options and len(options) > 1:
                 options.remove(prev_impact)
             choice = random.choice(options)
             prev_impact = choice
-            segment = sounds[choice]
+            to_play.append(choice)
+        elif name == "victory":
+            to_play.extend(["victory", "win_music", "applause"])
         elif name in sounds:
-            segment = sounds[name]
-        if segment is not None:
-            track = track.overlay(segment, position=int(ts * 1000))
+            to_play.append(name)
+
+        for sound_name in to_play:
+            if sound_name in sounds and config.SOUND_ENABLED.get(sound_name, True):
+                segment = sounds[sound_name]
+                track = track.overlay(segment, position=int(ts * 1000))
     return track

--- a/src/config.py
+++ b/src/config.py
@@ -280,6 +280,25 @@ ASSET_PATHS = {
 OUTPUT_DIR = "output"
 
 # ============================================================================
+# Paramètres audio
+# ============================================================================
+
+SOUND_ENABLED = {
+    "applause": True,
+    "bpm_loop": True,
+    "crash": True,
+    "fail": True,
+    "impact": True,
+    "impact1": True,
+    "impact2": True,
+    "impact3": True,
+    "pulley": True,
+    "timer": True,
+    "victory": True,
+    "win_music": True,
+}
+
+# ============================================================================
 # Configuration des effets visuels (VFX)
 # ============================================================================
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,3 +16,9 @@ def test_basic_constants():
     assert config.BLOCK_SIDE_ANGLE > 0
     assert config.BLOCK_ADHESION_FORCE >= 0
     assert isinstance(config.CAMERA_EFFECTS_ENABLED, bool)
+
+
+def test_sound_enabled_dict():
+    assert isinstance(config.SOUND_ENABLED, dict)
+    assert "bpm_loop" in config.SOUND_ENABLED
+    assert all(isinstance(v, bool) for v in config.SOUND_ENABLED.values())


### PR DESCRIPTION
## Summary
- add SOUND_ENABLED configuration to toggle individual audio files
- cut bpm_loop and play win music + applause on victory
- test that SOUND_ENABLED is defined

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_6865e8bda6bc83249e1b75cfe2ce0b91