### PR TITLE
Add fail sound mix and remove temp assets

### DIFF
--- a/src/audio/sound_manager.py
+++ b/src/audio/sound_manager.py
@@ -43,6 +43,8 @@ def mix_tracks(duration: int, events: List[Tuple[float, str]], sounds: Dict[str,
             to_play.append(choice)
         elif name == "victory":
             to_play.extend(["victory", "win_music", "applause"])
+        elif name == "fail":
+            to_play.extend(["fail", "fail_crowd", "fail_trumpet"])
         elif name in sounds:
             to_play.append(name)
 

--- a/src/config.py
+++ b/src/config.py
@@ -288,6 +288,8 @@ SOUND_ENABLED = {
     "bpm_loop": True,
     "crash": True,
     "fail": True,
+    "fail_crowd": True,
+    "fail_trumpet": True,
     "impact": True,
     "impact1": True,
     "impact2": True,


### PR DESCRIPTION
## Summary
- include new fail sound effects when a failure event occurs
- enable the new `fail_crowd` and `fail_trumpet` toggles
- remove placeholder sound files so they can be added manually later

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865ecd563c4832497c3b8690f0fcdb4